### PR TITLE
fix(nginx): update try_files directive for improved client-side routing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -6,7 +6,8 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
-        try_files $uri $uri/ /index.html;
+        # Try the actual file, then the file with .html extension, then fallback to index.html for client-side routing
+        try_files $uri $uri.html /index.html;
     }
 
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
This pull request includes a small but important change to the `nginx.conf` file. The change updates the `try_files` directive in the server configuration to improve client-side routing.

* [`nginx.conf`](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaL9-R10): Modified the `try_files` directive to first check for the actual file, then a file with a `.html` extension, and finally fall back to `index.html`. This ensures better handling of client-side routing scenarios.