### PR TITLE
feat(Dockerfile, nginx): add health check and improve Nginx configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,14 @@ RUN npm run build
 FROM nginx:stable-alpine
 COPY --from=builder /app/out /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Add curl for health checks
+RUN apk add --no-cache curl
+
 EXPOSE 3000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/health || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,17 +1,25 @@
 server {
     listen 3000;
     listen [::]:3000;
-    server_name localhost;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html index.htm;
 
-    location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        # Try the actual file, then the file with .html extension, then fallback to index.html for client-side routing
-        try_files $uri $uri.html /index.html;
+    # Health check endpoint for Coolify
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
     }
 
-    error_page   500 502 503 504  /50x.html;
+    # Main application routes
+    location / {
+        try_files $uri $uri.html $uri/ /index.html;
+    }
+
+    # Error pages
+    error_page 500 502 503 504 /50x.html;
     location = /50x.html {
-        root   /usr/share/nginx/html;
+        root /usr/share/nginx/html;
     }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the Dockerfile and `nginx.conf` to improve container health monitoring and streamline server configuration. Key changes include adding a health check mechanism, installing `curl` for health checks, and defining a dedicated health check endpoint in the Nginx configuration.

### Dockerfile Changes:
* Added `curl` installation to support health checks. (`RUN apk add --no-cache curl`)
* Configured a health check mechanism using `curl` to verify the application's availability. (`HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD curl -f http://localhost:3000/health || exit 1`)

### Nginx Configuration Changes:
* Introduced a `/health` endpoint for health checks, which returns a plain text response and disables access logging. (`location /health`)
* Updated the `try_files` directive to improve routing for the main application, ensuring proper handling of client-side routes. (`location /`)